### PR TITLE
LNX-95 Change `Get` to operate on deltas

### DIFF
--- a/src/scene_server.py
+++ b/src/scene_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from typing import List, Dict, Union
 
 from aioprocessing import AioPipe, AioProcess
 from aioprocessing.connection import AioConnection
@@ -17,7 +18,7 @@ def execution_runtime(pipe: AioConnection, object_id: int):
     from lynx.common.actions.action import Action
 
     scene_serialized = pipe.recv()
-    scene: Scene= Scene.deserialize(scene_serialized)
+    scene: Scene = Scene.deserialize(scene_serialized)
 
     def send(action: Action):
         pipe.send(action.serialize())
@@ -39,20 +40,36 @@ def execution_runtime(pipe: AioConnection, object_id: int):
 
 
 @dataclass
-class ProcessData():
+class ProcessData:
     process: AioProcess = None
     pipe: AioConnection = None
 
 
-class SceneServer():
+def calculate_deltas(from_tick_number: int, to_tick_number: int, actions_in_ticks: List[List[Union[str]]]) -> List[List[str]]:
+    deltas = []
+    for actions_in_tick in actions_in_ticks[(from_tick_number + 1):to_tick_number]:
+        deltas = deltas + actions_in_tick
+    return deltas
+
+
+class SceneServer:
     def __init__(self) -> None:
         self.app = FastAPI()
         self.scene = Scene()
         self.processes = {}
+        self.tick_number = 0
+        # each element represents actions applied in a consecutive tick
+        # TODO change to states = {self.scene.hash(): [None]}
+        self.applied_actions = [[]]
 
         @self.app.get("/")
-        async def get():
-            return {"scene": self.scene.serialize()}
+        async def get(tick_number: int) -> Dict[str, Union[int, str, List[List[str]]]]:
+            # if player has no scene or player tick number is incorrect
+            # TODO remove tick number and use scene hash instead e.g. if player_scene_hash not in self.states.keys():
+            if tick_number < 0 or tick_number > self.tick_number:
+                return {"tick_number": self.tick_number, "scene": self.scene.serialize()}
+            else:
+                return {"tick_number": self.tick_number, "deltas": calculate_deltas(self.tick_number, tick_number, self.applied_actions)}
 
         class AddObjectRequest(BaseModel):
             serialized_object: str
@@ -87,6 +104,9 @@ class SceneServer():
                 action = Entity.deserialize(serialized_action)
                 action.apply(self.scene)
 
+            self.applied_actions.append(serialized_actions)
+            self.tick_number += 1
+
             serialized_scene = self.scene.serialize()
             future_sends = []
             for process_data in self.processes.values():
@@ -95,7 +115,7 @@ class SceneServer():
             await asyncio.gather(*future_sends)
 
             return {"scene": serialized_scene}
-        
+
         @self.app.post("/tick_sync")
         async def tick_sync():
             actions = []

--- a/tests/calculate_deltas_test.py
+++ b/tests/calculate_deltas_test.py
@@ -1,0 +1,26 @@
+from typing import NoReturn
+
+from lynx.common.actions.move import Move
+from lynx.common.enums import Direction
+
+from src.scene_server import calculate_deltas
+
+
+class TestCalculateDeltas:
+    applied_actions = [
+        [],
+        [Move(object_id=123, vector=Direction.NORTH.value).serialize(), Move(object_id=124, vector=Direction.WEST.value).serialize()],
+        [Move(object_id=123, vector=Direction.SOUTH.value).serialize()],
+        [Move(object_id=345, vector=Direction.EAST.value).serialize(), Move(object_id=124, vector=Direction.EAST.value).serialize()],
+        [],
+        [Move(object_id=124, vector=Direction.NORTH.value).serialize(), Move(object_id=123, vector=Direction.WEST.value).serialize()]
+    ]
+    expected_deltas = [applied_actions[2][0], applied_actions[3][0], applied_actions[3][1]]
+
+    def test_success(self) -> NoReturn:
+        deltas = calculate_deltas(1, 4, self.applied_actions)
+        assert deltas == self.expected_deltas
+
+    def test_failure(self) -> NoReturn:
+        deltas = calculate_deltas(2, 4, self.applied_actions)
+        assert deltas != self.expected_deltas

--- a/tests/scene_server_test.py
+++ b/tests/scene_server_test.py
@@ -61,6 +61,6 @@ class TestSceneServer(asynctest.TestCase):
             data = await TestSceneServer.spam_objects(session, 100)
 
         async with aiohttp.ClientSession() as session:
-            response = await TestSceneServer.fetch(session, "http://0.0.0.0:8555/")
+            response = await TestSceneServer.fetch(session, "http://0.0.0.0:8555/?tick_number=-1")
         scene = Scene.deserialize(response['scene'])
         # TODO: assert scene contents


### PR DESCRIPTION
Each time `Actions` are applied to server `Scene`, they are saved in a serialized form along with a tick number.

Server and Player tick numbers can be used to determine `Actions` that led Player `Scene` to become Server `Scene`.

Such `Actions` are called **deltas**.

**Deltas** can be accessed at `/` endpoint. If player has no scene or player tick number is incorrect then serialized `Scene` is providead instead of deltas.

Notes:
In future, `Scene` state hashes will be used - see [LNX-96](https://gut-lynx.atlassian.net/browse/LNX-96).

[LNX-96]: https://gut-lynx.atlassian.net/browse/LNX-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ